### PR TITLE
restore-order works with composite key fn

### DIFF
--- a/src/main/com/wsscode/misc/coll.cljc
+++ b/src/main/com/wsscode/misc/coll.cljc
@@ -322,17 +322,29 @@
           {:id 2 :x \"d\"}
           {:id 3 :x \"c\"}]
 
+      (coll/restore-order
+        [{:id 1, :id2 1} {:id 2, :id2 0} {:id 3, :id2 1}]
+        #(select-keys % [:id :id2])
+        [{:id 4 :id2 0 :x \"a\"}
+         {:id 1 :id2 1 :x \"b\"}
+         {:id 3 :id2 1 :x \"c\"}
+         {:id 2 :id2 0 :x \"d\"}])
+
+      => [{:id 1 :id2 1 :x \"b\"}
+          {:id 2 :id2 0 :x \"d\"}
+          {:id 3 :id2 1 :x \"c\"}]
+
    Note it will also remove items that don't match anything in the original items
    list.
 
    In case the items contains a matching key more than once, the last one will be taken."
   ([inputs key items]
-   (restore-order inputs key items #(hash-map key (get % key))))
+   (restore-order inputs key items (if (ident? key) #(hash-map key (get % key)) key)))
   ([inputs key items default-fn]
    (let [index (index-by key items)]
      (into []
            (map (fn [input]
-                  (or (get index (get input key))
+                  (or (get index (key input))
                       (default-fn input))))
            inputs))))
 

--- a/test/com/wsscode/misc/coll_test.cljc
+++ b/test/com/wsscode/misc/coll_test.cljc
@@ -186,6 +186,25 @@
           {:my.entity/id 2}
           {:my.entity/id    3
            :my.entity/color :my.entity.color/green}]))
+  (is (= (coll/restore-order
+           [{:my.entity/id 1, :my.entity/id2 1}
+            {:my.entity/id 2, :my.entity/id2 0}
+            {:my.entity/id 3, :my.entity/id2 1}]
+           #(select-keys % [:my.entity/id :my.entity/id2])
+           [{:my.entity/id    3
+             :my.entity/id2   1
+             :my.entity/color :my.entity.color/green}
+            {:my.entity/id    1
+             :my.entity/id2   1
+             :my.entity/color :my.entity.color/purple}])
+         [{:my.entity/id    1
+           :my.entity/id2   1
+           :my.entity/color :my.entity.color/purple}
+          {:my.entity/id  2
+           :my.entity/id2 0}
+          {:my.entity/id    3
+           :my.entity/id2   1
+           :my.entity/color :my.entity.color/green}]))
   (is (= (coll/restore-order [{:my.entity/id 1}
                               {:my.entity/id 2}
                               {:my.entity/id 3}]
@@ -200,6 +219,26 @@
           {:my.entity/id    2
            :my.entity/color nil}
           {:my.entity/id    3
+           :my.entity/color :my.entity.color/green}]))
+  (is (= (coll/restore-order [{:my.entity/id 1, :my.entity/id2 1}
+                              {:my.entity/id 2, :my.entity/id2 0}
+                              {:my.entity/id 3, :my.entity/id2 1}]
+                             #(select-keys % [:my.entity/id :my.entity/id2])
+                             [{:my.entity/id    3
+                               :my.entity/id2   1
+                               :my.entity/color :my.entity.color/green}
+                              {:my.entity/id    1
+                               :my.entity/id2   1
+                               :my.entity/color :my.entity.color/purple}]
+                             (fn [x] (assoc x :my.entity/color nil)))
+         [{:my.entity/id    1
+           :my.entity/id2   1
+           :my.entity/color :my.entity.color/purple}
+          {:my.entity/id    2
+           :my.entity/id2   0
+           :my.entity/color nil}
+          {:my.entity/id    3
+           :my.entity/id2   1
            :my.entity/color :my.entity.color/green}])))
 
 (deftest restore-order2-test
@@ -216,6 +255,23 @@
              :my.entity/color :my.entity.color/purple}
             nil
             {:my.entity/id    3
+             :my.entity/color :my.entity.color/green}]))
+    (is (= (->> [{:my.entity/id    3
+                  :my.entity/id2   1
+                  :my.entity/color :my.entity.color/green}
+                 {:my.entity/id    1
+                  :my.entity/id2   1
+                  :my.entity/color :my.entity.color/purple}]
+                (coll/restore-order2 [{:my.entity/id 1, :my.entity/id2 1}
+                                      {:my.entity/id 2, :my.entity/id2 0}
+                                      {:my.entity/id 3, :my.entity/id2 1}]
+                                     #(select-keys % [:my.entity/id :my.entity/id2])))
+           [{:my.entity/id    1
+             :my.entity/id2   1
+             :my.entity/color :my.entity.color/purple}
+            nil
+            {:my.entity/id    3
+             :my.entity/id2   1
              :my.entity/color :my.entity.color/green}])))
   (testing "arity that works with ->> and default-fn"
     (is (= (->> [{:my.entity/id    3
@@ -232,6 +288,26 @@
             {:my.entity/id    2
              :my.entity/color nil}
             {:my.entity/id    3
+             :my.entity/color :my.entity.color/green}]))
+    (is (= (->> [{:my.entity/id    3
+                  :my.entity/id2   1
+                  :my.entity/color :my.entity.color/green}
+                 {:my.entity/id    1
+                  :my.entity/id2   1
+                  :my.entity/color :my.entity.color/purple}]
+                (coll/restore-order2 [{:my.entity/id 1, :my.entity/id2 1}
+                                      {:my.entity/id 2, :my.entity/id2 0}
+                                      {:my.entity/id 3, :my.entity/id2 1}]
+                                     #(select-keys % [:my.entity/id :my.entity/id2])
+                                     (fn [x] (assoc x :my.entity/color nil))))
+           [{:my.entity/id    1
+             :my.entity/id2   1
+             :my.entity/color :my.entity.color/purple}
+            {:my.entity/id    2
+             :my.entity/id2   0
+             :my.entity/color nil}
+            {:my.entity/id    3
+             :my.entity/id2   1
              :my.entity/color :my.entity.color/green}]))))
 
 (deftest conj-at-index-test


### PR DESCRIPTION
Now `restore-order` and `restore-order2` work with a composite key fn (or a keyword or symbol as before).

fixes #3